### PR TITLE
Faster sax

### DIFF
--- a/saxpy/hotsax.py
+++ b/saxpy/hotsax.py
@@ -43,7 +43,7 @@ def find_best_discord_hotsax(series, win_size, a_size, paa_size,
     all_znorms = znorms(series, win_size, znorm_threshold)
     """Find the best discord with hotsax."""
     """[1.0] get the sax data first"""
-    sax_none = sax_via_window(series, win_size, a_size, paa_size, "none", 0.01)
+    sax_none = sax_via_window(series, all_znorms, win_size, paa_size, a_size, "none")
 
     """[2.0] build the 'magic' array"""
     magic_array = list()

--- a/saxpy/hotsax.py
+++ b/saxpy/hotsax.py
@@ -62,8 +62,10 @@ def find_best_discord_hotsax(series, win_size, a_size, paa_size,
     visit_array = np.zeros(len(series), dtype=np.int)
 
     """[4.0] and we are off iterating over the magic array entries"""
-    for entry in m_arr:
-
+    # m_arr is sorted in reverse order of frequency.  We drop the last entry,
+    # since in a regular signal, this will be the most typical PAA string, and
+    # probably won't contain anomalies.
+    for entry in m_arr[:-1]:
         """[5.0] some moar of teh vars"""
         curr_word = entry[0]
         occurrences = sax_none[curr_word]
@@ -125,6 +127,8 @@ def find_best_discord_hotsax(series, win_size, a_size, paa_size,
                 curr_idx -= 1
 
                 """[15.0] and go random"""
+                ctr = 0
+                max_tries = 2000
                 while curr_idx >= 0:
                     rand_pos = it_order[curr_idx]
                     curr_idx -= 1
@@ -139,6 +143,9 @@ def find_best_discord_hotsax(series, win_size, a_size, paa_size,
                         nn_dist = dist
                     if dist < bestSoFarDistance:
                         nn_dist = dist
+                        break
+                    ctr += 1
+                    if ctr > max_tries:
                         break
 
             """[17.0] and BIGGER books"""

--- a/saxpy/hotsax.py
+++ b/saxpy/hotsax.py
@@ -1,6 +1,6 @@
 """Implements HOT-SAX."""
 import numpy as np
-from saxpy.znorm import znorm
+from saxpy.znorm import znorm, znorms
 from saxpy.sax import sax_via_window
 from saxpy.distance import euclidean
 
@@ -39,6 +39,8 @@ def find_discords_hotsax(series, win_size=100, num_discords=2, a_size=3,
 
 def find_best_discord_hotsax(series, win_size, a_size, paa_size,
                              znorm_threshold, globalRegistry): # noqa: C901
+    # comput all znorms ahead of time
+    all_znorms = znorms(series, win_size, znorm_threshold)
     """Find the best discord with hotsax."""
     """[1.0] get the sax data first"""
     sax_none = sax_via_window(series, win_size, a_size, paa_size, "none", 0.01)
@@ -80,8 +82,9 @@ def find_best_discord_hotsax(series, win_size, a_size, paa_size,
             visit_set = set(range(mark_start, mark_end))
 
             """[8.0] here is our subsequence in question"""
-            cur_seq = znorm(series[curr_pos:(curr_pos + win_size)],
-                            znorm_threshold)
+            cur_seq = all_znorms[curr_pos]
+            # cur_seq = znorm(series[curr_pos:(curr_pos + win_size)],
+            #                 znorm_threshold)
 
             """[9.0] let's see what is NN distance"""
             nn_dist = np.inf
@@ -97,8 +100,9 @@ def find_best_discord_hotsax(series, win_size, a_size, paa_size,
                     visit_set.add(next_pos)
 
                 """[12.0] distance we compute"""
-                dist = euclidean(cur_seq, znorm(series[next_pos:(
-                                 next_pos+win_size)], znorm_threshold))
+                dist = euclidean(cur_seq, all_znorms[next_pos])
+                # dist = euclidean(cur_seq, znorm(series[next_pos:(
+                #                  next_pos+win_size)], znorm_threshold))
                 distanceCalls += 1
 
                 """[13.0] keep the books up-to-date"""
@@ -125,8 +129,9 @@ def find_best_discord_hotsax(series, win_size, a_size, paa_size,
                     rand_pos = it_order[curr_idx]
                     curr_idx -= 1
 
-                    dist = euclidean(cur_seq, znorm(series[rand_pos:(
-                                     rand_pos + win_size)], znorm_threshold))
+                    dist = euclidean(cur_seq, all_znorms[rand_pos])
+                    # dist = euclidean(cur_seq, znorm(series[rand_pos:(
+                    #                  rand_pos + win_size)], znorm_threshold))
                     distanceCalls += 1
 
                     """[16.0] keep the books up-to-date again"""

--- a/saxpy/sax.py
+++ b/saxpy/sax.py
@@ -1,4 +1,6 @@
 """Converts a normlized timeseries to SAX symbols."""
+import numpy as np
+
 from collections import defaultdict
 from saxpy.strfunc import idx2letter
 from saxpy.znorm import znorm
@@ -52,12 +54,18 @@ def sax_via_window(series, all_znorms, win_size, paa_size, alphabet_size=3,
 
     prev_word = ''
 
+    all_paa_reps = np.apply_along_axis(
+        paa,
+        axis=1,
+        arr=all_znorms,
+        paa_segments=paa_size,
+    )
     for i in range(0, len(series) - win_size):
 
         zn = all_znorms[i]
 
-        paa_rep = paa(zn, paa_size)
-
+        # paa_rep = paa(zn, paa_size)
+        paa_rep = all_paa_reps[i]
         curr_word = ts_to_string(paa_rep, cuts)
 
         if '' != prev_word:

--- a/saxpy/sax.py
+++ b/saxpy/sax.py
@@ -44,8 +44,8 @@ def sax_by_chunking(series, paa_size, alphabet_size=3, z_threshold=0.01):
     return ts_to_string(paa_rep, cuts)
 
 
-def sax_via_window(series, win_size, paa_size, alphabet_size=3,
-                   nr_strategy='exact', z_threshold=0.01):
+def sax_via_window(series, all_znorms, win_size, paa_size, alphabet_size=3,
+                   nr_strategy='exact'):
     """Simple via window conversion implementation."""
     cuts = cuts_for_asize(alphabet_size)
     sax = defaultdict(list)
@@ -54,9 +54,7 @@ def sax_via_window(series, win_size, paa_size, alphabet_size=3,
 
     for i in range(0, len(series) - win_size):
 
-        sub_section = series[i:(i+win_size)]
-
-        zn = znorm(sub_section, z_threshold)
+        zn = all_znorms[i]
 
         paa_rep = paa(zn, paa_size)
 

--- a/saxpy/znorm.py
+++ b/saxpy/znorm.py
@@ -9,3 +9,15 @@ def znorm(series, znorm_threshold=0.01):
         return series
     mean = np.mean(series)
     return (series - mean) / sd
+
+
+def znorms(full_series, win_size, znorm_threshold=0.01):
+    idx = np.arange(win_size)[None, :] \
+            + np.arange(len(full_series) - win_size + 1)[:, None]
+    stds = np.expand_dims(np.std(full_series[idx], axis=1), axis=1)
+    stds[stds < znorm_threshold] = 1.0
+    means = np.expand_dims(np.mean(full_series[idx], axis=1), axis=1)
+    means[stds < znorm_threshold] = 0.0
+
+    znorms = (full_series[idx] - means) / stds
+    return znorms


### PR DESCRIPTION
Optimizations and a couple tricks to get this to be linear in size of sequence:

```python
In [3]: %timeit -r1 find_discords_hotsax(np.random.random(5000), num_discords=2)
8.85 s ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)

In [4]: %timeit -r1 find_discords_hotsax(np.random.random(10000), num_discords=2)
17.8 s ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)

In [5]: %timeit -r1 find_discords_hotsax(np.random.random(20000), num_discords=2)
36.1 s ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)

In [6]: %timeit -r1 find_discords_hotsax(np.random.random(40000), num_discords=2)
1min 18s ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)
```

Tricks: 

- precompute all znorms (old code does a lot of redundant calculations)
- don't search over most common PAA sequence (in sequences with no anomalies, these will dominate by far, and are the least interesting regions)
- limit random search.  as noted in the paper, random search is O(n2)
