### PR TITLE
Correct small bug in sa_via_window function

### DIFF
--- a/saxpy/sax.py
+++ b/saxpy/sax.py
@@ -52,7 +52,7 @@ def sax_via_window(series, win_size, paa_size, alphabet_size=3,
 
     prev_word = ''
 
-    for i in range(0, len(series) - win_size):
+    for i in range(0, len(series) - win_size + 1):
 
         sub_section = series[i:(i+win_size)]
 


### PR DESCRIPTION
In the current code, the for loop does not include the last observation of the time series, i.e., it stops one window too early. Thus, you need to add the '+1' so that the range function includes the last observation.